### PR TITLE
Fix unclickable items on message info more menu

### DIFF
--- a/src/components/Comment.vue
+++ b/src/components/Comment.vue
@@ -37,12 +37,9 @@
             v-click-outside="onClickMenuOutside"
             )
             ul
-              li
-                span(@click="replyHandler(comment)") Reply
-              li
-                span(@click="confirmDeleteComment(comment)") Delete
-              li
-                span(@click="messageInfoHandler(comment)") Message Info
+              li(@click="replyHandler(comment)") Reply
+              li(@click="confirmDeleteComment(comment)") Delete
+              li(@click="messageInfoHandler(comment)") Message Info
 
           //- CommentType: "location"
           static-map(:lat="comment.payload.latitude"


### PR DESCRIPTION
Previously we can only click on the text since the click handler delegeted on them. Whilst the list item is hoverable with pointer cursor, making user assume to click it.